### PR TITLE
Add a link to upstream release page on the PR message

### DIFF
--- a/workflow-templates/updater.yml
+++ b/workflow-templates/updater.yml
@@ -46,4 +46,5 @@ jobs:
           title: 'Upgrade to version ${{ env.VERSION }}'
           body: |
             Upgrade to v${{ env.VERSION }}
+            [See upstream release page](https://github.com/${{ env.REPO }}/releases/tag/v${{ env.VERSION }})
           draft: false


### PR DESCRIPTION
Add a link to upstream release page on the PR message
See the result on https://github.com/YunoHost-Apps/tooljet_ynh/pull/11
Need https://github.com/YunoHost/example_ynh/pull/186